### PR TITLE
Remove jcenter, add mavenCentral and Spring Plugins maven repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,10 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
+        maven {
+            url 'https://repo.spring.io/libs-milestone'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -34,7 +37,6 @@ repositories {
     google()
     mavenCentral()
 }
-
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
Adding maven repositories (Maven Central and Spring Plugins) to replace missing dependencies from jcenter.

This is a temporary fix before we upgrade to capacitor v4 which depends on more recent versions of the missing libraries.