### PR TITLE
[191] duplicated scopes on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">CapacitorGoogleAuth</h1>
 <p align="center"><strong><code>@codetrix-studio/capacitor-google-auth</code></strong></p>
-<p align="center"><strong>CAPACITOR 5</strong></p>
+<p align="center"><strong>CAPACITOR 7</strong></p>
 <p align="center">
 Capacitor plugin for Google Auth.
 </p>

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -86,12 +86,18 @@ public class GoogleAuth: CAPPlugin {
                     if self.additionalScopes.count > 0 {
                         // requesting additional scopes in GoogleSignIn-iOS SDK 6.0 requires that you sign the user in and then request additional scopes,
                         // there's no method to include the additional scopes in the initial sign in request
-                        self.googleSignIn.addScopes(self.additionalScopes, presenting: presentingVc) { user, error in
+                        self.googleSignIn.addScopes(self.additionalScopes, presenting: presentingVc) { userWithScopes, error in
                             if let error = error {
+                                // Indicates the requested scopes have already been granted to the currentUser. Hence we don't realy need it and previous `user` is good for us.
+                                guard !error.localizedDescription.contains("error -8") else {
+                                    print("Duplicated scopes, using previous user");
+                                    self.resolveSignInCallWith(user: user!)
+                                    return
+                                }
                                 self.signInCall?.reject(error.localizedDescription);
                                 return;
                             }
-                            self.resolveSignInCallWith(user: user!);
+                            self.resolveSignInCallWith(user: userWithScopes!);
                         }
                     } else {
                         self.resolveSignInCallWith(user: user!);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Google Auth plugin for capacitor.",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
# Resolves https://github.com/surgeventures/mastodon/issues/191

- Uses previous user if adding scope fails
- Bumps version