### PR TITLE
fix: drop dist/ from .npmignore so pnpm git-fetch keeps compiled output

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 # node files
-dist/
 node_modules/
 
 # iOS files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "7.2.0",
+  "version": "7.2.2",
   "description": "Google Auth plugin for capacitor.",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
## Problem

\`package.json#files\` allowlists \`dist/\`, but \`.npmignore\` also lists \`dist/\`.
\`npm pack\` resolves the conflict in favour of \`files\` (so \`npm publish\` works
fine — published tarball includes \`dist/\`). pnpm's git-fetch-then-pack flow
treats both as additive filters and ends up stripping
\`dist/esm/{web,definitions}.{js,d.ts,js.map}\` — only files referenced by
\`main\`/\`types\` (i.e. \`index.*\`) survive.

Result: any consumer pulling this package via
\`github:surgeventures/CapacitorGoogleAuth#<tag>\` under pnpm gets a package
where \`dist/esm/index.js\` does \`import('./web')\` and
\`export * from './definitions'\` against files that aren't there. rspack /
webpack fail with module-not-found at build time.

## Fix

Remove \`dist/\` from \`.npmignore\`. \`package.json#files\` already controls
inclusion (allowlist), \`.gitignore\` still keeps \`dist/\` out of source
control, and pnpm consumers now get all 9 compiled files instead of 3.

\`npm publish\` behaviour is unchanged — \`files\` was already the source of
truth there.

Also bumps \`package.json#version\` from \`7.2.0\` (stale at the v7.2.1 tag)
to \`7.2.2\` to skip past the gap.

## Test plan

- [x] Local repro: \`pnpm install\` of \`github:surgeventures/CapacitorGoogleAuth#v7.2.2\` from another repo produces all 9 dist files in node_modules.
- [x] \`tsc\` still emits \`dist/esm/*\` correctly during \`prepare\`.