### PR TITLE
chore: redirect actions to freshaengineering + pin to SHA

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,20 +1,20 @@
 version: 1
-generated_at: 2026-05-25T15:34:22Z
+generated_at: 2026-06-11T15:33:14Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
-      - v2
+      - ee0669bd1cc54295c223e0bb666b733df41de1c5
     occurrences:
-      v2:
+      ee0669bd1cc54295c223e0bb666b733df41de1c5:
         .github/workflows/npmpublish.yml:
           - jobs.build.steps.[0].uses
           - jobs.publish-npm.steps.[0].uses
   - action: actions/setup-node
     refs:
-      - v1
+      - f1f314fca9dfce2769ece7d933488f076716723e
     occurrences:
-      v1:
+      f1f314fca9dfce2769ece7d933488f076716723e:
         .github/workflows/npmpublish.yml:
           - jobs.build.steps.[1].uses
           - jobs.publish-npm.steps.[1].uses

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 16
       - run: npm ci
@@ -19,8 +19,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- Redirects all `surgeventures/platform-tribe-actions` references to `freshaengineering/platform-tribe-actions`
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following 5 commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA